### PR TITLE
Accomodate for Versioned extension when adding

### DIFF
--- a/code/SearchableDataObject.php
+++ b/code/SearchableDataObject.php
@@ -19,8 +19,15 @@ class SearchableDataObject extends DataExtension {
 		parent::onAfterWrite();
 		
 		if (in_array('Searchable', class_implements($this->owner->class))) {
-			$filterID = "`{$this->owner->class}`.`ID`={$this->owner->ID}";			
-			$do = DataObject::get($this->owner->class, $filterID, false)->filter($this->owner->getSearchFilter())->first();
+			if($this->owner->hasExtension('Versioned')) {
+		            $filterID = array('ID' => $this->owner->ID);
+		            $filter = $filterID + $this->owner->getSearchFilter();
+		            $do = Versioned::get_by_stage($this->owner->class, 'Live')->filter($filter)->first();
+		        } else {
+		            $filterID = "`{$this->owner->class}`.`ID`={$this->owner->ID}";
+		            $do = DataObject::get($this->owner->class, $filterID, false)->filter($this->owner->getSearchFilter())->first();
+		        }
+		        
 			if ($do) {
 				PopulateSearch::insert($do);
 			} else {


### PR DESCRIPTION
Problem: There isn't any implementation for DataObjects using Versioned extension. When we retrieve the DataObjects during the result search, it causes a blank screen as it can't resolve 'staging' models. 

Solution: Check if the model is using the Versioned extension then pull out the model accordingly with adjusted filter.