### PR TITLE
Accomodate for Versioned extension in PopulateSearch

### DIFF
--- a/code/Tasks/PopulateSearch.php
+++ b/code/Tasks/PopulateSearch.php
@@ -110,10 +110,14 @@ class PopulateSearch extends BuildTask {
 		$searchables = ClassInfo::implementorsOf('Searchable');
 		foreach ($searchables as $class) {
 			// Filter
-			
 			$dos = $class::get()->filter($class::getSearchFilter());
-			
-			$dos = $class::get()->filter(array());
+
+		        $versionedCheck = $dos->first();
+		
+		        if($versionedCheck->hasExtension('Versioned')) {
+		            $dos = Versioned::get_by_stage($class, 'Live')->filter($class::getSearchFilter());
+		        }
+
 			foreach ($dos as $do) {
 				self::insert($do);
 			}


### PR DESCRIPTION
Problem: There isn't any implementation for DataObjects using Versioned extension. When we retrieve the DataObjects during the result search, it causes a blank screen as it can't resolve 'staging' models. 

Solution: Check if the model is using the Versioned extension then grab the 'Live' DataObjects to pull into the table instead.

Extra bonus: Bug with the original code as you had two declarations of $dos with the latter overriding the prior. It does not pull in the getSearchFilter function into the filter (uses empty array instead).