### PR TITLE
Improving handling of the start parameter

### DIFF
--- a/code/CustomSearch.php
+++ b/code/CustomSearch.php
@@ -51,11 +51,7 @@ class CustomSearch extends Extension {
 		$list = new ArrayList();
 
 		$v = $request->getVars();
-		if (!isset($v["start"]))
-			$v["start"] = 0;
-
 		$q = $v["Search"];
-		$s = max(intval($v["start"]), 0);
 
 		$input = DB::getConn()->addslashes($q);
 		$data = DB::query("SELECT * FROM SearchableDataObjects WHERE MATCH (Title, Content) AGAINST ('$input' IN NATURAL LANGUAGE MODE)");
@@ -70,11 +66,8 @@ class CustomSearch extends Extension {
 		}
 
 		$pageLength = Config::inst()->get('CustomSearch', 'items_per_page');
-		$ret = new PaginatedList($list);
+		$ret = new PaginatedList($list, $request);
 		$ret->setPageLength($pageLength);
-		$ret->setPageStart($s);
-		$ret->setTotalItems($list->count());
-		$ret->setLimitItems($pageLength);
 
 		return $ret;
 	}

--- a/code/CustomSearch.php
+++ b/code/CustomSearch.php
@@ -55,7 +55,7 @@ class CustomSearch extends Extension {
 			$v["start"] = 0;
 
 		$q = $v["Search"];
-		$s = $v["start"];
+		$s = max(intval($v["start"]), 0);
 
 		$input = DB::getConn()->addslashes($q);
 		$data = DB::query("SELECT * FROM SearchableDataObjects WHERE MATCH (Title, Content) AGAINST ('$input' IN NATURAL LANGUAGE MODE)");


### PR DESCRIPTION
If a non-numeric value is provided in the `start` parameter, an `InvalidArgumentException` will be thrown.

If a negative value is provided, the pagination will display things like _Page -3 of 5_

The [PaginatedList](http://api.silverstripe.org/master/class-PaginatedList.html#___construct) constructor can accept the request as a second argument. It will handle the validation automatically.

Just a suggestion.

