### PR TITLE
Prevent PHP Strict Notice in CustomSearch::getSearchResults()

### DIFF
--- a/code/CustomSearch.php
+++ b/code/CustomSearch.php
@@ -116,6 +116,20 @@ class CustomSearch extends Extension {
 		foreach ($data as $row) {
 
 			$do = DataObject::get_by_id($row['ClassName'], $row['ID']);
+
+            /*
+             * Skip rows from SearchableDataObjects where the row data fails to
+             * look up a valid DataObject using the claimed ClassName and ID to
+             * prevent PHP notice:
+             *
+             *      [Strict Notice] Creating default object from empty value
+             *
+             * caused when DataObject::get_by_id() returns false
+             */
+            if(!is_object($do) || !$do->exists()) {
+                continue;
+            }
+
 			$do->Title = $row['Title'];
 			$do->Content = $row['Content'];
 

--- a/code/CustomSearch.php
+++ b/code/CustomSearch.php
@@ -118,22 +118,23 @@ class CustomSearch extends Extension {
 			$do = DataObject::get_by_id($row['ClassName'], $row['ID']);
 
             /*
-             * Skip rows from SearchableDataObjects where the row data fails to
-             * look up a valid DataObject using the claimed ClassName and ID to
+             * Check that we have been returned a valid DataObject, using the
+             * ClassName and ID stored in the SortableDataObject DB table, to
              * prevent PHP notice:
              *
              *      [Strict Notice] Creating default object from empty value
              *
              * caused when DataObject::get_by_id() returns false
              */
-            if(!is_object($do) || !$do->exists()) {
-                continue;
+            if(is_object($do) && $do->exists()) {
+            
+                $do->Title = $row['Title'];
+                $do->Content = $row['Content'];
+
+                $list->push($do);
+
             }
 
-			$do->Title = $row['Title'];
-			$do->Content = $row['Content'];
-
-			$list->push($do);
 		}
 
 		$pageLength = Config::inst()->get('CustomSearch', 'items_per_page');


### PR DESCRIPTION
Prevent PHP Strict Notice when DataObject::get_by_id() fails to return a valid DataObject in CustomSearch::getSearchResults().

CustomSearch::getSearchResults() previously assumed that all rows of the SearchableDataObjects DB table will successfully return a valid DataObject when executing the following:

```$do = DataObject::get_by_id($row['ClassName'], $row['ID']);```

There are scenarios when this will return false (meaning $do contains the value of false) and then the following two lines will throw a PHP Strict Notice (as you cannot use the ->property syntax on a variable which contains anything but an object and false !== an object):

![screen shot 2015-10-07 at 17 28 56](https://cloud.githubusercontent.com/assets/5114645/10344052/1bb9e1d6-6d19-11e5-88c3-d505a6f9b086.png)

I identified this issue as I had upgraded my SS blog module to a newer version where the BlogEntry class was replaced with BlogPost. My database therefore contained a number of outdated values for the DB's SiteTree table ClassName fields (which read BlogEntry instead of BlogPost). This in turn meant my SearchableDataObjects DB table was full of rows containing ClassName values of BlogEntry.

This meant numerous calls to ``` DataObject::get_by_id("BlogEntry", 123);``` which returns false, presumably because the BlogEntry class no longer exists in the code base.

I expect there will be other instances where peoples databases will contain outdated, inaccurate data and this will end up in the SearchableDataObjects table, causing the same issue.
