### PR TITLE
BUG SQL where statement breaks extended data objects

### DIFF
--- a/code/SearchableDataObject.php
+++ b/code/SearchableDataObject.php
@@ -24,7 +24,7 @@ class SearchableDataObject extends DataExtension {
 		            $filter = $filterID + $this->owner->getSearchFilter();
 		            $do = Versioned::get_by_stage($this->owner->class, 'Live')->filter($filter)->first();
 		        } else {
-		            $filterID = "`{$this->owner->class}`.`ID`={$this->owner->ID}";
+		            $filterID = "`{$this->findParentClass()}`.`ID`={$this->owner->ID}";
 		            $do = DataObject::get($this->owner->class, $filterID, false)->filter($this->owner->getSearchFilter())->first();
 		        }
 		        
@@ -61,5 +61,18 @@ class SearchableDataObject extends DataExtension {
 												) ENGINE=MyISAM");
     DB::query("ALTER TABLE SearchableDataObjects ADD FULLTEXT (`Title` ,`Content`)");
   }
+  
+	/**
+	 * Recursive function to find the parent class of the current data object
+	 */
+	private function findParentClass($class = null) {
+		if(is_null($class)) {
+			$class = $this->owner->class;
+		}
+
+		$parent = singleton($class)->parentClass();
+
+		return $parent === 'DataObject' ? $class : $this->findParentClass($parent);
+	}
 	
 }


### PR DESCRIPTION
I have a dataobject called Interaction that implements the ```SearchableLinkable``` class, and then I have other dataobjects that extend Interaction like so:

```
class Interaction extends DataObject implements SearchableLinkable {

}

class Exhibition extends Interaction {

}
```

Currently if I save an Exhibition data object in the CMS I get this error:

```
ERROR [User Error]: Couldn't run query: 
SELECT DISTINCT "Interaction"."ClassName", "Interaction"."Created", "Interaction"."LastEdited", "Interaction"
."Title", "Interaction"."Content", "Interaction"."DateStart", "Interaction"."DateEnd", "Interaction"
."Type", "Interaction"."SortID", "Interaction"."URLSegment", "Interaction"."FeaturedImageID", "Interaction"
."VeeziURLID", "Interaction"."PageID", "Interaction"."ID", CASE WHEN "Interaction"."ClassName" IS NOT
 NULL THEN "Interaction"."ClassName" ELSE 'Interaction' END AS "RecordClassName"
FROM "Interaction"
WHERE (`Exhibition`.`ID`=1) AND ("Interaction"."ClassName" IN ('Exhibition'))
ORDER BY "Interaction"."SortID" ASC
LIMIT 1 

Unknown column 'Exhibition.ID' in 'where clause'
IN POST /om/admin/pages/edit/EditForm/field/Exhibitions/item/1/ItemEditForm
Line 598 in /var/www/om/framework/model/MySQLDatabase.php
```




The problem is that when the ```SearchableDataObject->onAfterWrite()``` is called on an extended data object that doesn't inherit ```SearchableLinkable``` directly, ```$this->owner->class``` is the incorrect value to use, and instead it should return ```$this->owner->parentClass``` as data objects that extend another are actually stored in the same table as the parent data object in the database.

My PR corrects the where clause in this particular scenario by first checking if the data object has a parent class, and if so, use that instead of the data object's class.

