### PR TITLE
Force case insensitiveness on search

### DIFF
--- a/code/Tasks/PopulateSearch.php
+++ b/code/Tasks/PopulateSearch.php
@@ -21,7 +21,7 @@ class PopulateSearch extends BuildTask {
 													Content text NOT NULL,
 													PageID integer NOT NULL DEFAULT 0,
 													PRIMARY KEY(ID, ClassName)
-												) ENGINE=MyISAM");
+												) ENGINE=MyISAM CHARACTER SET=utf8 COLLATE utf8_unicode_ci");
 		DB::query("ALTER TABLE SearchableDataObjects ADD FULLTEXT (`Title` ,`Content`)");
 	}
 	


### PR DESCRIPTION
MATCH...AGAINST uses the actual collation, i.e. if your table has
e.g. utf8_unicode_ci the search will be case insensitive but if you have
utf8_bin (or any other _bin collation) the comparation will be case
sensitive.

Although SilverStripe says otherwise (utf8_general_ci), the tables are
created preserving the default collation of the database. Tested
experimentally with 3.3.0.
