### PR TITLE
FIX: remove SearchForm results() function from allowed_actions

### DIFF
--- a/code/CustomSearch.php
+++ b/code/CustomSearch.php
@@ -21,8 +21,7 @@ class CustomSearch extends Extension
     private static $search_controller = 'SearchPage';
 
     private static $allowed_actions = array(
-            'SearchForm',
-            'results',
+        'SearchForm',
     );
 
     /**


### PR DESCRIPTION
Relates to https://github.com/g4b0/silverstripe-searchable-dataobjects/issues/42